### PR TITLE
Add DVTPlugInCompatibilityUUID for Xcode 5.1

### DIFF
--- a/ClangFormat/ClangFormat-Info.plist
+++ b/ClangFormat/ClangFormat-Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>
 		<string>640F884E-CE55-4B40-87C0-8869546CAB7A</string>
 		<string>37B30044-3B14-46BA-ABAA-F01000C27B63</string>
 	</array>


### PR DESCRIPTION
I think this is needed for Xcode 5.1 support, released March 10th.
