### PR TITLE
Specify principal class (NSPrincipalClass) in Info.plist.

### DIFF
--- a/ClangFormat/ClangFormat-Info.plist
+++ b/ClangFormat/ClangFormat-Info.plist
@@ -31,6 +31,8 @@
 		<string>AD68E85B-441B-4301-B564-A45E4919A6AD</string>
 		<string>C4A681B0-4A26-480E-93EC-1218098B9AA0</string>
 	</array>
+	<key>NSPrincipalClass</key>
+	<string>TRVSClangFormat</string>
 	<key>XC4Compatible</key>
 	<true/>
 	<key>XCGCReady</key>


### PR DESCRIPTION
Otherwise it will depend on compilation order and the plugin may seemingly-randomly fail to load silently. (fixes #72)