### PR TITLE
Add DVTPlugInCompatibilityUUID for Xcode 6.3(6D570)

### DIFF
--- a/ClangFormat/ClangFormat-Info.plist
+++ b/ClangFormat/ClangFormat-Info.plist
@@ -24,6 +24,7 @@
 	<string>1</string>
 	<key>DVTPlugInCompatibilityUUIDs</key>
 	<array>
+		<string>9F75337B-21B4-4ADC-B558-F9CADF7073A7</string>
 		<string>A16FF353-8441-459E-A50C-B071F53F51B7</string>
 		<string>FEC992CC-CA4A-4CFD-8881-77300FCB848A</string>
 		<string>A2E4D43F-41F4-4FB9-BB94-7177011C9AED</string>


### PR DESCRIPTION
UUID is '9F75337B-21B4-4ADC-B558-F9CADF7073A7'