### PR TITLE
Add ".hh" to allowable extensions for code formatting

### DIFF
--- a/ClangFormat/NSDocument+TRVSClangFormat.m
+++ b/ClangFormat/NSDocument+TRVSClangFormat.m
@@ -57,7 +57,7 @@ static BOOL trvs_formatOnSave;
 }
 
 - (BOOL)trvs_shouldFormat {
-    return [[NSSet setWithObjects:@"c", @"h", @"cpp", @"cc", @"hpp", @"ipp", @"m", @"mm", nil] containsObject:[[[self fileURL] pathExtension] lowercaseString]];
+    return [[NSSet setWithObjects:@"c", @"h", @"cpp", @"cc", @"hpp", @"ipp", @"m", @"mm", @"hh", nil] containsObject:[[[self fileURL] pathExtension] lowercaseString]];
 }
 
 @end


### PR DESCRIPTION
Some folks use this to indicate an Objective C++ file.