### PR TITLE
Fixed a crash and a logic error, gitignore updated

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,6 +18,7 @@ profile
 DerivedData
 *.hmap
 *.ipa
+project.xcworkspace
 
 # CocoaPods
 Pods

--- a/ClangFormat/TRVSFormatter.m
+++ b/ClangFormat/TRVSFormatter.m
@@ -95,7 +95,8 @@
   [self formatRanges:@[ [NSValue valueWithRange:NSMakeRange(0, length)] ]
           inDocument:document];
 
-  NSUInteger diff = labs(length - [[document textStorage] length]);
+  NSUInteger textStorageLength = [[document textStorage] length];
+  NSUInteger diff = MAX(length, textStorageLength) - MIN(length, textStorageLength);
 
   BOOL documentIsLongerAfterFormatting =
       length > [[document textStorage] length];

--- a/ClangFormat/TRVSFormatter.m
+++ b/ClangFormat/TRVSFormatter.m
@@ -225,7 +225,9 @@
                                                  encoding:NSUTF8StringEncoding];
     outputPath = [outputPath
         stringByTrimmingCharactersInSet:[NSCharacterSet newlineCharacterSet]];
-    if ([outputPath length]) {
+      
+    BOOL isDirectory = NO;
+    if ([[NSFileManager defaultManager] fileExistsAtPath:outputPath isDirectory:&isDirectory] && !isDirectory) {
       executablePath = outputPath;
     }
   }


### PR DESCRIPTION
Fixed a crash with oh-my-zsh, whose 'which clang-format' command returns 'clang-format not found', instead of an empty string.

Fixed a logic error: abs(unsigned long - unsigned long) doesn't make sense.

git ignore file added xcworkspace