### PR TITLE
Allow format selected range without explicit selection.

### DIFF
--- a/ClangFormat/TRVSFormatter.m
+++ b/ClangFormat/TRVSFormatter.m
@@ -50,9 +50,8 @@
 }
 
 - (void)formatSelectedCharacters {
-  if (![TRVSXcode textViewHasSelection])
-    return;
-
+  // Even if there is no selection, go one and perform a format with 0-length
+  // range. This will format the statement under cursor.
   [self formatRanges:[[TRVSXcode textView] selectedRanges]
           inDocument:[TRVSXcode sourceCodeDocument]];
 }


### PR DESCRIPTION
Allow format selected range without explicit selection, in which case the current state under the cursor will be formatted.
