### PR TITLE
Fix includes sorting

### DIFF
--- a/ClangFormat/TRVSCodeFragment.m
+++ b/ClangFormat/TRVSCodeFragment.m
@@ -79,7 +79,15 @@
                        lineRange:(NSRange)lineRange
                            block:(void (^)(NSString *formattedString,
                                            NSError *error))block {
-  NSURL *tmpFileURL = [self.fileURL URLByAppendingPathExtension:@"trvs"];
+  NSString *fileName = [self.fileURL lastPathComponent];
+  NSURL *tmpDirURL = [[self.fileURL URLByDeletingLastPathComponent]
+      URLByAppendingPathComponent:@"ClangFormatXcodeTmpDir"];
+  [[NSFileManager defaultManager] createDirectoryAtURL:tmpDirURL
+                           withIntermediateDirectories:YES
+                                            attributes:nil
+                                                 error:nil];
+
+  NSURL *tmpFileURL = [tmpDirURL URLByAppendingPathComponent:fileName];
   [self.string writeToURL:tmpFileURL
                atomically:YES
                  encoding:NSUTF8StringEncoding
@@ -125,7 +133,7 @@
                                        }]
             : nil);
 
-  [[NSFileManager defaultManager] removeItemAtURL:tmpFileURL error:NULL];
+  [[NSFileManager defaultManager] removeItemAtURL:tmpDirURL error:NULL];
 }
 
 @end


### PR DESCRIPTION
Issue: when `SortIncludes` option is enabled, the plugin incorrectly sorts includes in `.cpp` files. This is caused by the fact that `clang-format` is invoked on a temporary file which is named by appending `.trvs` extension to the original file name. File name change prevents `clang-format` to correctly determine the main header for a source file and put it on top of includes list.

Fix: preserve original file name and copy the file to a temporary directory `ClangFormatXcodeTmpDir` inside original directory.
